### PR TITLE
allRank reusability

### DIFF
--- a/allrank/config.py
+++ b/allrank/config.py
@@ -81,18 +81,22 @@ class Config:
     def from_json(cls, config_path):
         with open(config_path) as config_file:
             config = json.load(config_file)
-            config["model"] = ModelConfig(**config["model"])
-            if config["model"].transformer:
-                config["model"].transformer = TransformerConfig(**config["model"].transformer)
-                if config["model"].transformer.positional_encoding:
-                    config["model"].transformer.positional_encoding = PositionalEncoding(
-                        **config["model"].transformer.positional_encoding)
-            config["data"] = DataConfig(**config["data"])
-            config["optimizer"] = NameArgsConfig(**config["optimizer"])
-            config["training"] = TrainingConfig(**config["training"])
-            config["metrics"] = cls._parse_metrics(config["metrics"])
-            config["lr_scheduler"] = NameArgsConfig(**config["lr_scheduler"])
-            config["loss"] = NameArgsConfig(**config["loss"])
+            return Config.from_dict(config)
+
+    @classmethod
+    def from_dict(cls, config):
+        config["model"] = ModelConfig(**config["model"])
+        if config["model"].transformer:
+            config["model"].transformer = TransformerConfig(**config["model"].transformer)
+            if config["model"].transformer.positional_encoding:
+                config["model"].transformer.positional_encoding = PositionalEncoding(
+                    **config["model"].transformer.positional_encoding)
+        config["data"] = DataConfig(**config["data"])
+        config["optimizer"] = NameArgsConfig(**config["optimizer"])
+        config["training"] = TrainingConfig(**config["training"])
+        config["metrics"] = cls._parse_metrics(config["metrics"])
+        config["lr_scheduler"] = NameArgsConfig(**config["lr_scheduler"])
+        config["loss"] = NameArgsConfig(**config["loss"])
         return cls(**config)
 
     @staticmethod

--- a/allrank/utils/file_utils.py
+++ b/allrank/utils/file_utils.py
@@ -19,15 +19,15 @@ class PathsContainer:
     config_path = attrib(type=str)
 
     @classmethod
-    def from_args(cls, output, run_id, config_file_name):
+    def from_args(cls, output, run_id, config_file_name, package_name="allrank"):
         base_output_path = get_path_from_local_uri(output)
         output_dir = os.path.join(base_output_path, "results", run_id)
         tensorboard_output_path = os.path.join(base_output_path, "tb_evals", "single", run_id)
         config_path = os.path.join(config_file_name)
         if not os.path.exists(config_path):
-            logger.info("extracting config file path from package")
+            logger.info("extracting config file path from package {}".format(package_name))
             config_path = resource_filename(Requirement.parse(
-                "allrank"), os.path.join("allrank", config_file_name))
+                package_name), os.path.join(package_name, config_file_name))
         logger.info("will read config from {}".format(config_path))
         return cls(base_output_path, output_dir, tensorboard_output_path, config_path)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ reqs = [
     "torch==1.2.0",
     "torchvision==0.4.0",
     "scikit-learn==0.21.3",
-    "pandas==0.25.0",
+    "pandas==0.24.2",
     "numpy==1.16.1",
     "scipy>=1.2.0",
     "attrs==18.2.0",


### PR DESCRIPTION
This PR makes it easier to use allRank as a dependency

1. Ability to create config out of a dict, not necessarily from a file
2. Ability to specify custom package name from which config file is read
3. Fallback to pandas 0.24.2 for backwards compatibility to environments running on python 3.5.2