### PR TITLE
NeuralNDCG, 1.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ This framework was developed to support the research project [Context-Aware Lear
   volume={abs/2005.10084}
 }
 ```
+Additionally, if you use the NeuralNDCG loss function, please cite the corresponding work, [NeuralNDCG: Direct Optimisation of a Ranking Metric via Differentiable Relaxation of Sorting](https://arxiv.org/abs/2102.07831):
+```
+@article{Pobrotyn2021NeuralNDCG,
+  title={NeuralNDCG: Direct Optimisation of a Ranking Metric via Differentiable Relaxation of Sorting},
+  author={Przemyslaw Pobrotyn and Radoslaw Bialobrzeski},
+  journal={ArXiv},
+  year={2020},
+  volume={abs/2102.07831}
+}
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We hope that allRank will facilitate both research in neural LTR and its industr
 ## Features
 
 ### Implemented loss functions:
- 1. ListNet (For a binary and graded relevance)
+ 1. ListNet (for binary and graded relevance)
  2. ListMLE
  3. RankNet
  4. Ordinal loss
@@ -25,6 +25,7 @@ We hope that allRank will facilitate both research in neural LTR and its industr
  6. LambdaLoss
  7. ApproxNDCG
  8. RMSE
+ 9. NeuralNDCG (introduced in https://arxiv.org/pdf/2102.07831)
 
 ### Getting started guide
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Additionally, if you use the NeuralNDCG loss function, please cite the correspon
   title={NeuralNDCG: Direct Optimisation of a Ranking Metric via Differentiable Relaxation of Sorting},
   author={Przemyslaw Pobrotyn and Radoslaw Bialobrzeski},
   journal={ArXiv},
-  year={2020},
+  year={2021},
   volume={abs/2102.07831}
 }
 ```

--- a/allrank/models/losses/__init__.py
+++ b/allrank/models/losses/__init__.py
@@ -5,6 +5,7 @@ from .binary_listNet import *  # noqa F403 F401
 from .lambdaLoss import *  # noqa F403 F401
 from .listMLE import *  # noqa F403 F401
 from .listNet import *  # noqa F403 F401
+from .neuralNDCG import *  # noqa F403 F401
 from .ordinal import *  # noqa F403 F401
 from .pointwise import *  # noqa F403 F401
 from .rankNet import *  # noqa F403 F401

--- a/allrank/models/losses/loss_utils.py
+++ b/allrank/models/losses/loss_utils.py
@@ -1,0 +1,112 @@
+import torch
+import numpy as np
+
+from allrank.models.losses import DEFAULT_EPS
+from allrank.models.model_utils import get_torch_device
+
+
+def sinkhorn_scaling(mat, mask=None, tol=1e-6, max_iter=50):
+    """
+    Sinkhorn scaling procedure.
+    :param mat: a tensor of square matrices of shape N x M x M, where N is batch size
+    :param mask: a tensor of masks of shape N x M
+    :param tol: Sinkhorn scaling tolerance
+    :param max_iter: maximum number of iterations of the Sinkhorn scaling
+    :return: a tensor of (approximately) doubly stochastic matrices
+    """
+    if mask is not None:
+        mat = mat.masked_fill(mask[:, None, :] | mask[:, :, None], 0.0)
+        mat = mat.masked_fill(mask[:, None, :] & mask[:, :, None], 1.0)
+
+    for _ in range(max_iter):
+        mat = mat / mat.sum(dim=1, keepdim=True).clamp(min=DEFAULT_EPS)
+        mat = mat / mat.sum(dim=2, keepdim=True).clamp(min=DEFAULT_EPS)
+
+        if torch.max(torch.abs(mat.sum(dim=2) - 1.)) < tol and torch.max(torch.abs(mat.sum(dim=1) - 1.)) < tol:
+            break
+
+    if mask is not None:
+        mat = mat.masked_fill(mask[:, None, :] | mask[:, :, None], 0.0)
+
+    return mat
+
+
+def deterministic_neural_sort(s, tau, mask):
+    """
+    Deterministic neural sort.
+    Code taken from "Stochastic Optimization of Sorting Networks via Continuous Relaxations", ICLR 2019.
+    Minor modifications applied to the original code (masking).
+    :param s: values to sort, shape [batch_size, slate_length]
+    :param tau: temperature for the final softmax function
+    :param mask: mask indicating padded elements
+    :return: approximate permutation matrices of shape [batch_size, slate_length, slate_length]
+    """
+    dev = get_torch_device()
+
+    n = s.size()[1]
+    one = torch.ones((n, 1), dtype=torch.float32, device=dev)
+    s = s.masked_fill(mask[:, :, None], -1e8)
+    A_s = torch.abs(s - s.permute(0, 2, 1))
+    A_s = A_s.masked_fill(mask[:, :, None] | mask[:, None, :], 0.0)
+
+    B = torch.matmul(A_s, torch.matmul(one, torch.transpose(one, 0, 1)))
+
+    temp = [n - m + 1 - 2 * (torch.arange(n - m, device=dev) + 1) for m in mask.squeeze(-1).sum(dim=1)]
+    temp = [t.type(torch.float32) for t in temp]
+    temp = [torch.cat((t, torch.zeros(n - len(t), device=dev))) for t in temp]
+    scaling = torch.stack(temp).type(torch.float32).to(dev)  # type: ignore
+
+    s = s.masked_fill(mask[:, :, None], 0.0)
+    C = torch.matmul(s, scaling.unsqueeze(-2))
+
+    P_max = (C - B).permute(0, 2, 1)
+    P_max = P_max.masked_fill(mask[:, :, None] | mask[:, None, :], -np.inf)
+    P_max = P_max.masked_fill(mask[:, :, None] & mask[:, None, :], 1.0)
+    sm = torch.nn.Softmax(-1)
+    P_hat = sm(P_max / tau)
+    return P_hat
+
+
+def sample_gumbel(samples_shape, device, eps=1e-10) -> torch.Tensor:
+    """
+    Sampling from Gumbel distribution.
+    Code taken from "Stochastic Optimization of Sorting Networks via Continuous Relaxations", ICLR 2019.
+    Minor modifications applied to the original code (masking).
+    :param samples_shape: shape of the output samples tensor
+    :param device: device of the output samples tensor
+    :param eps: epsilon for the logarithm function
+    :return: Gumbel samples tensor of shape samples_shape
+    """
+    U = torch.rand(samples_shape, device=device)
+    return -torch.log(-torch.log(U + eps) + eps)
+
+
+def stochastic_neural_sort(s, n_samples, tau, mask, beta=1.0, log_scores=True, eps=1e-10):
+    """
+    Stochastic neural sort. Please note that memory complexity grows by factor n_samples.
+    Code taken from "Stochastic Optimization of Sorting Networks via Continuous Relaxations", ICLR 2019.
+    Minor modifications applied to the original code (masking).
+    :param s: values to sort, shape [batch_size, slate_length]
+    :param n_samples: number of samples (approximations) for each permutation matrix
+    :param tau: temperature for the final softmax function
+    :param mask: mask indicating padded elements
+    :param beta: scale parameter for the Gumbel distribution
+    :param log_scores: whether to apply the logarithm function to scores prior to Gumbel perturbation
+    :param eps: epsilon for the logarithm function
+    :return: approximate permutation matrices of shape [n_samples, batch_size, slate_length, slate_length]
+    """
+    dev = get_torch_device()
+
+    batch_size = s.size()[0]
+    n = s.size()[1]
+    s_positive = s + torch.abs(s.min())
+    samples = beta * sample_gumbel([n_samples, batch_size, n, 1], device=dev)
+    if log_scores:
+        s_positive = torch.log(s_positive + eps)
+
+    s_perturb = (s_positive + samples).view(n_samples * batch_size, n, 1)
+    mask_repeated = mask.repeat_interleave(n_samples, dim=0)
+
+    P_hat = deterministic_neural_sort(s_perturb, tau, mask_repeated)
+    P_hat = P_hat.view(n_samples, batch_size, n, n)
+    return P_hat

--- a/allrank/models/losses/neuralNDCG.py
+++ b/allrank/models/losses/neuralNDCG.py
@@ -1,0 +1,136 @@
+import torch
+
+from allrank.data.dataset_loading import PADDED_Y_VALUE
+from allrank.models.losses import DEFAULT_EPS
+from allrank.models.losses.loss_utils import deterministic_neural_sort, sinkhorn_scaling, stochastic_neural_sort
+from allrank.models.metrics import dcg
+from allrank.models.model_utils import get_torch_device
+
+
+def neuralNDCG(y_pred, y_true, padded_value_indicator=PADDED_Y_VALUE, temperature=1., powered_relevancies=True, k=None,
+               stochastic=False, n_samples=32, beta=0.1, log_scores=True):
+    """
+    NeuralNDCG loss introduced in "NeuralNDCG: Direct Optimisation of a Ranking Metric via Differentiable
+    Relaxation of Sorting" - https://arxiv.org/abs/2102.07831. Based on the NeuralSort algorithm.
+    :param y_pred: predictions from the model, shape [batch_size, slate_length]
+    :param y_true: ground truth labels, shape [batch_size, slate_length]
+    :param padded_value_indicator: an indicator of the y_true index containing a padded item, e.g. -1
+    :param temperature: temperature for the NeuralSort algorithm
+    :param powered_relevancies: whether to apply 2^x - 1 gain function, x otherwise
+    :param k: rank at which the loss is truncated
+    :param stochastic: whether to calculate the stochastic variant
+    :param n_samples: how many stochastic samples are taken, used if stochastic == True
+    :param beta: beta parameter for NeuralSort algorithm, used if stochastic == True
+    :param log_scores: log_scores parameter for NeuralSort algorithm, used if stochastic == True
+    :return: loss value, a torch.Tensor
+    """
+    dev = get_torch_device()
+
+    if k is None:
+        k = y_true.shape[1]
+
+    mask = (y_true == padded_value_indicator)
+    # Choose the deterministic/stochastic variant
+    if stochastic:
+        P_hat = stochastic_neural_sort(y_pred.unsqueeze(-1), n_samples=n_samples, tau=temperature, mask=mask,
+                                       beta=beta, log_scores=log_scores)
+    else:
+        P_hat = deterministic_neural_sort(y_pred.unsqueeze(-1), tau=temperature, mask=mask).unsqueeze(0)
+
+    # Perform sinkhorn scaling to obtain doubly stochastic permutation matrices
+    P_hat = sinkhorn_scaling(P_hat.view(P_hat.shape[0] * P_hat.shape[1], P_hat.shape[2], P_hat.shape[3]),
+                             mask.repeat_interleave(P_hat.shape[0], dim=0), tol=1e-6, max_iter=50)
+    P_hat = P_hat.view(int(P_hat.shape[0] / y_pred.shape[0]), y_pred.shape[0], P_hat.shape[1], P_hat.shape[2])
+
+    # Mask P_hat and apply to true labels, ie approximately sort them
+    P_hat = P_hat.masked_fill(mask[None, :, :, None] | mask[None, :, None, :], 0.)
+    y_true_masked = y_true.masked_fill(mask, 0.).unsqueeze(-1).unsqueeze(0)
+    if powered_relevancies:
+        y_true_masked = torch.pow(2., y_true_masked) - 1.
+
+    ground_truth = torch.matmul(P_hat, y_true_masked).squeeze(-1)
+    discounts = (torch.tensor(1.) / torch.log2(torch.arange(y_true.shape[-1], dtype=torch.float) + 2.)).to(dev)
+    discounted_gains = ground_truth * discounts
+
+    if powered_relevancies:
+        idcg = dcg(y_true, y_true, ats=[k]).permute(1, 0)
+    else:
+        idcg = dcg(y_true, y_true, ats=[k], gain_function=lambda x: x).permute(1, 0)
+
+    discounted_gains = discounted_gains[:, :, :k]
+    ndcg = discounted_gains.sum(dim=-1) / (idcg + DEFAULT_EPS)
+    idcg_mask = idcg == 0.
+    ndcg = ndcg.masked_fill(idcg_mask.repeat(ndcg.shape[0], 1), 0.)
+
+    assert (ndcg < 0.).sum() >= 0, "every ndcg should be non-negative"
+    if idcg_mask.all():
+        return torch.tensor(0.)
+
+    mean_ndcg = ndcg.sum() / ((~idcg_mask).sum() * ndcg.shape[0])  # type: ignore
+    return -1. * mean_ndcg  # -1 cause we want to maximize NDCG
+
+
+def neuralNDCG_transposed(y_pred, y_true, padded_value_indicator=PADDED_Y_VALUE, temperature=1.,
+                          powered_relevancies=True, k=None, stochastic=False, n_samples=32, beta=0.1, log_scores=True,
+                          max_iter=50, tol=1e-6):
+    """
+    NeuralNDCG Transposed loss introduced in "NeuralNDCG: Direct Optimisation of a Ranking Metric via Differentiable
+    Relaxation of Sorting" - https://arxiv.org/abs/2102.07831. Based on the NeuralSort algorithm.
+    :param y_pred: predictions from the model, shape [batch_size, slate_length]
+    :param y_true: ground truth labels, shape [batch_size, slate_length]
+    :param padded_value_indicator: an indicator of the y_true index containing a padded item, e.g. -1
+    :param temperature: temperature for the NeuralSort algorithm
+    :param powered_relevancies: whether to apply 2^x - 1 gain function, x otherwise
+    :param k: rank at which the loss is truncated
+    :param stochastic: whether to calculate the stochastic variant
+    :param n_samples: how many stochastic samples are taken, used if stochastic == True
+    :param beta: beta parameter for NeuralSort algorithm, used if stochastic == True
+    :param log_scores: log_scores parameter for NeuralSort algorithm, used if stochastic == True
+    :param max_iter: maximum iteration count for Sinkhorn scaling
+    :param tol: tolerance for Sinkhorn scaling
+    :return: loss value, a torch.Tensor
+    """
+    dev = get_torch_device()
+
+    if k is None:
+        k = y_true.shape[1]
+
+    mask = (y_true == padded_value_indicator)
+
+    if stochastic:
+        P_hat = stochastic_neural_sort(y_pred.unsqueeze(-1), n_samples=n_samples, tau=temperature, mask=mask,
+                                       beta=beta, log_scores=log_scores)
+    else:
+        P_hat = deterministic_neural_sort(y_pred.unsqueeze(-1), tau=temperature, mask=mask).unsqueeze(0)
+
+    # Perform sinkhorn scaling to obtain doubly stochastic permutation matrices
+    P_hat_masked = sinkhorn_scaling(P_hat.view(P_hat.shape[0] * y_pred.shape[0], y_pred.shape[1], y_pred.shape[1]),
+                                    mask.repeat_interleave(P_hat.shape[0], dim=0), tol=tol, max_iter=max_iter)
+    P_hat_masked = P_hat_masked.view(P_hat.shape[0], y_pred.shape[0], y_pred.shape[1], y_pred.shape[1])
+    discounts = (torch.tensor(1) / torch.log2(torch.arange(y_true.shape[-1], dtype=torch.float) + 2.)).to(dev)
+
+    # This takes care of the @k metric truncation - if something is @>k, it is useless and gets 0.0 discount
+    discounts[k:] = 0.
+    discounts = discounts[None, None, :, None]
+
+    # Here the discounts become expected discounts
+    discounts = torch.matmul(P_hat_masked.permute(0, 1, 3, 2), discounts).squeeze(-1)
+    if powered_relevancies:
+        gains = torch.pow(2., y_true) - 1
+        discounted_gains = gains.unsqueeze(0) * discounts
+        idcg = dcg(y_true, y_true, ats=[k]).squeeze()
+    else:
+        gains = y_true
+        discounted_gains = gains.unsqueeze(0) * discounts
+        idcg = dcg(y_true, y_true, ats=[k]).squeeze()
+
+    ndcg = discounted_gains.sum(dim=2) / (idcg + DEFAULT_EPS)
+    idcg_mask = idcg == 0.
+    ndcg = ndcg.masked_fill(idcg_mask, 0.)
+
+    assert (ndcg < 0.).sum() >= 0, "every ndcg should be non-negative"
+    if idcg_mask.all():
+        return torch.tensor(0.)
+
+    mean_ndcg = ndcg.sum() / ((~idcg_mask).sum() * ndcg.shape[0])  # type: ignore
+    return -1. * mean_ndcg  # -1 cause we want to maximize NDCG

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ reqs = [
 
 setup(
     name="allRank",
-    version="1.3.2",
+    version="1.4.0",
     description="allRank is a framework for training learning-to-rank neural models",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 
 reqs = [
-    "torch==1.6.0",
-    "torchvision==0.7.0",
+    "torch>=1.6.0, <=1.8.0",
+    "torchvision>=0.7.0, <= 0.9.0",
     "scikit-learn>=0.23.0",
     "pandas>=1.0.5",
     "numpy>=1.18.5",
@@ -16,7 +16,8 @@ reqs = [
     "attrs>=19.3.0",
     "flatten_dict>=0.3.0",
     "tensorboardX>=2.1.0",
-    "gcsfs==0.6.2"
+    "gcsfs==0.6.2",
+    "google-auth==1.27.1"
 ]
 
 setup(

--- a/tests/losses/test_neuralndcg.py
+++ b/tests/losses/test_neuralndcg.py
@@ -1,0 +1,94 @@
+import math
+
+from functools import partial
+from pytest import approx
+
+from allrank.data.dataset_loading import PADDED_Y_VALUE
+from tests.losses.utils import neuralNDCG_wrap, ndcg_wrap
+
+
+test_cases = [{"stochastic": False, "transposed": False},
+              {"stochastic": True, "transposed": False},
+              {"stochastic": False, "transposed": True},
+              {"stochastic": True, "transposed": True}]
+
+
+def test_neuralNDCG_simple():
+    for tc in test_cases:
+        neuralNDCG_simple(partial(neuralNDCG_wrap, **tc))
+
+
+def neuralNDCG_simple(fun):
+    y_pred = [0.5, 0.2]
+    y_true = [1.0, 0.0]
+
+    result = fun(y_pred, y_true)
+    expected = ndcg_wrap(y_pred, y_true)
+
+    assert math.isfinite(result)
+    assert (-1 * result == approx(expected))
+
+
+def test_neuralNDCG_longer():
+    for tc in test_cases:
+        neuralNDCG_longer(partial(neuralNDCG_wrap, **tc))
+
+
+def neuralNDCG_longer(fun):
+    y_pred = [0.5, 0.2, 0.1, 0.4, 1.0, -1.0, 0.63]
+    y_true = [1.0, 2.0, 2.0, 4.0, 1.0, 4.0, 3.0]
+
+    result = fun(y_pred, y_true)
+    expected = ndcg_wrap(y_pred, y_true)
+
+    assert math.isfinite(result)
+    assert (-1 * result == approx(expected))
+
+
+def test_neuralNDCG_stable_for_very_small_prediction():
+    for tc in test_cases:
+        neuralNDCG_stable_for_very_small_prediction(partial(neuralNDCG_wrap, **tc))
+
+
+def neuralNDCG_stable_for_very_small_prediction(fun):
+    y_pred = [0.5, -1e30]
+    y_true = [1.0, 0.0]
+
+    result = fun(y_pred, y_true)
+    expected = ndcg_wrap(y_pred, y_true)
+
+    assert math.isfinite(result)
+    assert (-1 * result == approx(expected))
+
+
+def test_neuralNDCG_ignores_padded_value():
+    for tc in test_cases:
+        neuralNDCG_ignores_padded_value(partial(neuralNDCG_wrap, **tc))
+
+
+def neuralNDCG_ignores_padded_value(fun):
+    y_pred = [0.5, 0.2, 0.1, 0.4, 1.0, -1.0, 0.63, 1., 0.5, 0.3]
+    y_true = [1.0, 2.0, 2.0, 4.0, 1.0, 4.0, 3.0, PADDED_Y_VALUE, PADDED_Y_VALUE, PADDED_Y_VALUE]
+
+    result = fun(y_pred, y_true, temperature=0.001)
+    expected = ndcg_wrap(y_pred, y_true)
+
+    assert math.isfinite(result)
+    assert (-1 * result == approx(expected))
+
+
+def test_neuralNDCG_at_3():
+    for tc in test_cases:
+        neuralNDCG_at_3(partial(neuralNDCG_wrap, **tc))
+
+
+def neuralNDCG_at_3(fun):
+    y_pred = [0.5, 0.2, 0.1, 0.4, 1.0, -1.0, 0.63]
+    y_true = [1.0, 2.0, 2.0, 4.0, 1.0, 4.0, 3.0]
+    ats = 3
+
+    result = fun(y_pred, y_true, k=ats)
+    expected = ndcg_wrap(y_pred, y_true, ats=[ats])
+
+    assert math.isfinite(result)
+    assert (-1 * result == approx(expected))

--- a/tests/losses/utils.py
+++ b/tests/losses/utils.py
@@ -1,0 +1,21 @@
+import torch
+
+from allrank.models.losses.neuralNDCG import neuralNDCG, neuralNDCG_transposed
+from allrank.models.metrics import ndcg
+
+
+def neuralNDCG_wrap(
+        y_pred, y_true, temperature=1e-4, powered_relevancies=True, k=None, stochastic=False,
+        n_samples=1024, beta=0.001, transposed=False):
+    if transposed:
+        fun = neuralNDCG_transposed  # type: ignore
+    else:
+        fun = neuralNDCG  # type: ignore
+
+    return fun(torch.tensor([y_pred]), torch.tensor([y_true]), temperature=temperature,
+               powered_relevancies=powered_relevancies, k=k,
+               stochastic=stochastic, n_samples=n_samples, beta=beta).item()
+
+
+def ndcg_wrap(y_pred, y_true, ats=None):
+    return ndcg(torch.tensor([y_pred]), torch.tensor([y_true]), ats=ats).mean().item()


### PR DESCRIPTION
This PR introduces NeuralNDCG, a loss function for direct optimisation of NDCG metric ([arxiv link](https://arxiv.org/abs/2102.07831)). The loss function is implemented in two variants - standard (approximating each position's gain) and transposed (approximating each document's discount).

Required Pytorch and torchvision versions are now ranges, 1.6.0-1.8.0 and 0.7.0-0.9.0, respectively.

Because of these relatively important changes, a minor version bump is done to 1.4.0 version.