### PR TITLE
NDCG filler value

### DIFF
--- a/allrank/models/losses/lambdaLoss.py
+++ b/allrank/models/losses/lambdaLoss.py
@@ -95,12 +95,12 @@ def ndcgLoss2_scheme(G, D, *args):
     return deltas[None, :, :] * torch.abs(G[:, :, None] - G[:, None, :])
 
 
-def lamdbaRank_scheme(G, D, *args):
+def lambdaRank_scheme(G, D, *args):
     return torch.abs(torch.pow(D[:, :, None], -1.) - torch.pow(D[:, None, :], -1.)) * torch.abs(G[:, :, None] - G[:, None, :])
 
 
 def ndcgLoss2PP_scheme(G, D, *args):
-    return args[0] * ndcgLoss2_scheme(G, D) + lamdbaRank_scheme(G, D)
+    return args[0] * ndcgLoss2_scheme(G, D) + lambdaRank_scheme(G, D)
 
 
 def rankNet_scheme(G, D, *args):

--- a/allrank/models/metrics.py
+++ b/allrank/models/metrics.py
@@ -4,7 +4,8 @@ import torch
 from allrank.data.dataset_loading import PADDED_Y_VALUE
 
 
-def ndcg(y_pred, y_true, ats=None, gain_function=lambda x: torch.pow(2, x) - 1, padding_indicator=PADDED_Y_VALUE):
+def ndcg(y_pred, y_true, ats=None, gain_function=lambda x: torch.pow(2, x) - 1, padding_indicator=PADDED_Y_VALUE,
+         filler_value=1.0):
     """
     Normalized Discounted Cumulative Gain at k.
 
@@ -14,12 +15,13 @@ def ndcg(y_pred, y_true, ats=None, gain_function=lambda x: torch.pow(2, x) - 1, 
     :param ats: optional list of ranks for NDCG evaluation, if None, maximum rank is used
     :param gain_function: callable, gain function for the ground truth labels, e.g. torch.pow(2, x) - 1
     :param padding_indicator: an indicator of the y_true index containing a padded item, e.g. -1
+    :param filler_value: a filler NDCG value to use when there are no relevant items in listing
     :return: NDCG values for each slate and rank passed, shape [batch_size, len(ats)]
     """
     idcg = dcg(y_true, y_true, ats, gain_function, padding_indicator)
     ndcg_ = dcg(y_pred, y_true, ats, gain_function, padding_indicator) / idcg
     idcg_mask = idcg == 0
-    ndcg_[idcg_mask] = 0.  # if idcg == 0 , set ndcg to 0
+    ndcg_[idcg_mask] = filler_value  # if idcg == 0 , set ndcg to filler_value
 
     assert (ndcg_ < 0.0).sum() >= 0, "every ndcg should be non-negative"
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ reqs = [
 
 setup(
     name="allRank",
-    version="1.4.0",
+    version="1.4.1",
     description="allRank is a framework for training learning-to-rank neural models",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR introduces a filler NDCG value for examples with no relevant items (IDCG == 0). By default, it's 1.0, like in popular gradient boosting libraries.

Also, a typo in `lambdaloss.py` is fixed.