### PR TITLE
Reproducibility guide

### DIFF
--- a/allrank/data/dataset_loading.py
+++ b/allrank/data/dataset_loading.py
@@ -242,5 +242,5 @@ def create_data_loaders(train_ds: LibSVMDataset, val_ds: LibSVMDataset, num_work
 
     # Please note that the batch size for validation dataloader is twice the total_batch_size
     train_dl = DataLoader(train_ds, batch_size=total_batch_size, num_workers=num_workers, shuffle=True)
-    val_dl = DataLoader(val_ds, batch_size=total_batch_size * 2, num_workers=num_workers, shuffle=False)
+    val_dl = DataLoader(val_ds, batch_size=total_batch_size, num_workers=num_workers, shuffle=False)
     return train_dl, val_dl

--- a/reproducibility/HOWTO.md
+++ b/reproducibility/HOWTO.md
@@ -1,0 +1,46 @@
+# allRank MSLR-WEB30K reproducibility guide
+
+## Introduction
+In this guide we provide all the necessary information to reproduce allRank results from papers
+[Context-Aware Learning to Rank with Self-Attention](https://arxiv.org/abs/2005.10084) and [NeuralNDCG: Direct Optimisation of a Ranking Metric via Differentiable Relaxation of Sorting](https://arxiv.org/abs/2102.07831) on the [MSLR-WEB30K dataset](https://www.microsoft.com/en-us/research/project/mslr/).
+
+## Data preprocessing
+The same preprocessing steps were used for both papers. They are performed by the `normalize_features.py` script. Some features are only standardised, while most are log-transformed before standardisation. The script takes three parameters:
+* `--ds_path` - path to the MSLR-WEB30K fold to preprocess
+* `--features_without_logarithm` - features to standardise without prior log-transform
+* `--features_negative` - features that need to be shifted by a constant to ensure strict positivity prior to log-transform
+
+Default values (used in both papers) of `--features_without_logarithm` and `--features_negative` are supplied in the script.
+Please note that the script needs to be run on each MSLR-WEB30K fold separately.
+
+## Configuration files
+Selected configuration files are supplied in the `configs/` directory. For Context-Aware Learning to Rank with Self-Attention, they are MLP and context-aware rankers with two loss functions:
+* ordinal loss, the best-performing context-aware ranker
+* NDCGLoss2++, the best-performing MLP ranker
+
+Configuration files for NeuralNDCG: Direct Optimisation of a Ranking Metric via Differentiable Relaxation of Sorting are context-aware rankers trained with loss functions:
+* NeuralNDCG@max, the best-performing NeuralNDCG variant
+* ApproxNDCG, another direct NDCG optimization method
+* LambdaRank@max, the best-performing loss function
+
+Please remember about filling the correct dataset path in the configuration files. These files can be adapted for any other loss function/model combination, requiring only minor changes in model and loss function parameters.
+
+**Important** - in case of any OOM errors on folds 2 and 4 and Context-Aware Learning to Rank configuration files, please try reducing the batch size to 32.
+## Notes
+The results in the first paper are averaged (+ standard deviation) on validation subsets of five dataset folds while the NeuralNDCG paper supplies a single number, the Fold 1 test subset result.
+
+The whole dataset has ~3% queries with no relevant items resulting in IDCG == 0. Following XGBoost and LightGBM default behaviour, we assume NDCG = 1 for such queries.
+The results can be rescaled for other IDCG == 0 treatment methods without the need to re-run any experiment.
+For example, one can rescale the result from NDCG = 1 to  NDCG = 0 treatment by applying a simple formula: ```avg_ndcg - (num_blank/num_all)```.
+Below is a table with the number of "blank" queries for each fold of the dataset and train/validation/test sets.
+
+|      |   Train   |         |    Test   |         | Validation |         |
+|:----:|:---------:|:-------:|:---------:|:-------:|:----------:|---------|
+| Fold | num_blank | num_all | num_blank | num_all | num_blank  | num_all |
+| 1    | 602       | 18919   | 189       | 6306    | 191        | 6306    |
+| 2    | 587       | 18918   | 206       | 6307    | 189        | 6306    |
+| 3    | 581       | 18918   | 195       | 6306    | 206        | 6307    |
+| 4    | 586       | 18919   | 201       | 6306    | 195        | 6306    |
+| 5    | 590       | 18919   | 191       | 6306    | 201        | 6306    |
+
+The configuration files were doublechecked prior to release on GCP AI Platform `n1-highmem16` machines with P100 GPUs.

--- a/reproducibility/configs/contextaware_web30k/ndcgloss2pp.json
+++ b/reproducibility/configs/contextaware_web30k/ndcgloss2pp.json
@@ -1,0 +1,67 @@
+{
+  "model": {
+    "fc_model": {
+      "sizes": [
+        128
+      ],
+      "input_norm": false,
+      "activation": null,
+      "dropout": 0.0
+    },
+    "transformer": {
+      "N": 4,
+      "d_ff": 512,
+      "h": 4,
+      "positional_encoding": null,
+      "dropout": 0.3
+    },
+    "post_model": {
+      "output_activation": null,
+      "d_output": 1
+    }
+  },
+  "data": {
+    "path": "MLSR-WEB30K-FOLD1-PATH",
+    "validation_ds_role": "vali",
+    "num_workers": 1,
+    "batch_size": 64,
+    "slate_length": 240
+  },
+  "optimizer": {
+    "name": "Adam",
+    "args": {
+      "lr": 0.001
+    }
+  },
+  "lr_scheduler": {
+    "name": "StepLR",
+    "args": {
+      "step_size": 50,
+      "gamma": 0.1
+    }
+  },
+  "training": {
+    "epochs": 100,
+    "early_stopping_patience": 100,
+    "gradient_clipping_norm": null
+  },
+  "val_metric": "ndcg_5",
+  "metrics": [
+    "ndcg_5",
+    "ndcg_10"
+  ],
+  "loss": {
+    "name": "lambdaLoss",
+    "args": {
+      "weighing_scheme": "ndcgLoss2PP_scheme",
+      "k": null,
+      "mu": 10,
+      "sigma": 1.0
+    }
+  },
+  "expected_metrics" : {
+    "val": {
+      "ndcg_5": 0.50
+    }
+  }
+}

--- a/reproducibility/configs/contextaware_web30k/ndcgloss2pp_mlp.json
+++ b/reproducibility/configs/contextaware_web30k/ndcgloss2pp_mlp.json
@@ -1,0 +1,63 @@
+{
+  "model": {
+    "fc_model": {
+      "sizes": [
+        256, 512, 1024, 512, 256
+      ],
+      "input_norm": false,
+      "activation": "ReLU",
+      "dropout": 0.3
+    },
+    "transformer": null,
+    "post_model": {
+      "output_activation": null,
+      "d_output": 1
+    }
+  },
+  "data": {
+    "path": "MLSR-WEB30K-FOLD1-PATH",
+    "validation_ds_role": "vali",
+    "num_workers": 1,
+    "batch_size": 64,
+    "slate_length": 240
+  },
+  "optimizer": {
+    "name": "Adam",
+    "args": {
+      "lr": 0.001
+    }
+  },
+  "lr_scheduler": {
+    "name": "StepLR",
+    "args": {
+      "step_size": 50,
+      "gamma": 0.1
+    }
+  },
+  "training": {
+    "epochs": 100,
+    "early_stopping_patience": 100,
+    "gradient_clipping_norm": null
+  },
+  "val_metric": "ndcg_5",
+  "metrics": [
+    "ndcg_5",
+    "ndcg_10",
+    "ndcg_30",
+    "ndcg_60"
+  ],
+  "loss": {
+    "name": "lambdaLoss",
+    "args": {
+      "weighing_scheme": "ndcgLoss2PP_scheme",
+      "k": null,
+      "mu": 10,
+      "sigma": 1.0
+    }
+  },
+  "expected_metrics" : {
+    "val": {
+      "ndcg_5": 0.45
+    }
+  }
+}

--- a/reproducibility/configs/contextaware_web30k/ordinal.json
+++ b/reproducibility/configs/contextaware_web30k/ordinal.json
@@ -1,0 +1,64 @@
+{
+  "model": {
+    "fc_model": {
+      "sizes": [
+        144
+      ],
+      "input_norm": false,
+      "activation": null,
+      "dropout": 0.0
+    },
+    "transformer": {
+      "N": 4,
+      "d_ff": 512,
+      "h": 2,
+      "positional_encoding": null,
+      "dropout": 0.4
+    },
+    "post_model": {
+      "output_activation": "Sigmoid",
+      "d_output": 4
+    }
+  },
+  "data": {
+    "path": "MLSR-WEB30K-FOLD1-PATH",
+    "validation_ds_role": "vali",
+    "num_workers": 1,
+    "batch_size": 64,
+    "slate_length": 240
+  },
+  "optimizer": {
+    "name": "Adam",
+    "args": {
+      "lr": 0.001
+    }
+  },
+  "lr_scheduler": {
+    "name": "StepLR",
+    "args": {
+      "step_size": 50,
+      "gamma": 0.1
+    }
+  },
+  "training": {
+    "epochs": 100,
+    "early_stopping_patience": 100,
+    "gradient_clipping_norm": null
+  },
+  "val_metric": "ndcg_5",
+  "metrics": [
+    "ndcg_5",
+    "ndcg_10"
+  ],
+  "loss": {
+    "name": "ordinal",
+    "args": {
+      "n": 4
+    }
+  },
+  "expected_metrics" : {
+    "val": {
+      "ndcg_5": 0.50
+    }
+  }
+}

--- a/reproducibility/configs/contextaware_web30k/ordinal_mlp.json
+++ b/reproducibility/configs/contextaware_web30k/ordinal_mlp.json
@@ -1,0 +1,60 @@
+{
+  "model": {
+    "fc_model": {
+      "sizes": [
+        256, 512, 1024, 512, 256
+      ],
+      "input_norm": false,
+      "activation": "ReLU",
+      "dropout": 0.3
+    },
+    "transformer": null,
+    "post_model": {
+      "output_activation": "Sigmoid",
+      "d_output": 4
+    }
+  },
+  "data": {
+    "path": "MLSR-WEB30K-FOLD1-PATH",
+    "validation_ds_role": "vali",
+    "num_workers": 1,
+    "batch_size": 64,
+    "slate_length": 240
+  },
+  "optimizer": {
+    "name": "Adam",
+    "args": {
+      "lr": 0.001
+    }
+  },
+  "lr_scheduler": {
+    "name": "StepLR",
+    "args": {
+      "step_size": 50,
+      "gamma": 0.1
+    }
+  },
+  "training": {
+    "epochs": 100,
+    "early_stopping_patience": 100,
+    "gradient_clipping_norm": null
+  },
+  "val_metric": "ndcg_5",
+  "metrics": [
+    "ndcg_5",
+    "ndcg_10",
+    "ndcg_30",
+    "ndcg_60"
+  ],
+  "loss": {
+    "name": "ordinal",
+    "args": {
+      "n": 4
+    }
+  },
+  "expected_metrics" : {
+    "val": {
+      "ndcg_5": 0.45
+    }
+  }
+}

--- a/reproducibility/configs/neuralndcg_web30k/approxndcg.json
+++ b/reproducibility/configs/neuralndcg_web30k/approxndcg.json
@@ -1,0 +1,66 @@
+{
+  "model": {
+    "fc_model": {
+      "sizes": [96],
+      "input_norm": false,
+      "activation": null,
+      "dropout": 0.0
+    },
+    "transformer": {
+      "N": 2,
+      "d_ff": 384,
+      "h": 1,
+      "positional_encoding" : null,
+      "dropout": 0.1
+    },
+    "post_model": {
+      "output_activation": null,
+      "d_output": 1
+    }
+  },
+  "data": {
+    "path": "MLSR-WEB30K-FOLD1-PATH",
+    "validation_ds_role": "test",
+    "num_workers": 1,
+    "batch_size": 64,
+    "slate_length": 240
+  },
+  "optimizer": {
+    "name": "Adam",
+    "args": {
+      "lr": 0.001
+    }
+  },
+  "lr_scheduler": {
+    "name": "StepLR",
+    "args": {
+      "step_size": 50,
+      "gamma": 0.1
+    }
+  },
+  "training": {
+    "epochs": 100,
+    "early_stopping_patience": 100,
+    "gradient_clipping_norm": null
+  },
+  "val_metric": "ndcg_5",
+  "metrics": [
+    "ndcg_5",
+    "ndcg_10",
+    "ndcg_30",
+    "ndcg_60"
+  ],
+  "loss": {
+    "name": "approxNDCGLoss",
+    "args":
+    {
+      "alpha": 1.0
+    }
+  },
+  "detect_anomaly": false,
+  "expected_metrics" : {
+    "val": {
+      "ndcg_5": 0.49
+    }
+  }
+}

--- a/reproducibility/configs/neuralndcg_web30k/lambdarank_atmax.json
+++ b/reproducibility/configs/neuralndcg_web30k/lambdarank_atmax.json
@@ -1,0 +1,68 @@
+{
+  "model": {
+    "fc_model": {
+      "sizes": [96],
+      "input_norm": false,
+      "activation": null,
+      "dropout": 0.0
+    },
+    "transformer": {
+      "N": 2,
+      "d_ff": 384,
+      "h": 1,
+      "positional_encoding" : null,
+      "dropout": 0.1
+    },
+    "post_model": {
+      "output_activation": null,
+      "d_output": 1
+    }
+  },
+  "data": {
+    "path": "MLSR-WEB30K-FOLD1-PATH",
+    "validation_ds_role": "test",
+    "num_workers": 1,
+    "batch_size": 64,
+    "slate_length": 240
+  },
+  "optimizer": {
+    "name": "Adam",
+    "args": {
+      "lr": 0.001
+    }
+  },
+  "lr_scheduler": {
+    "name": "StepLR",
+    "args": {
+      "step_size": 50,
+      "gamma": 0.1
+    }
+  },
+  "training": {
+    "epochs": 100,
+    "early_stopping_patience": 100,
+    "gradient_clipping_norm": null
+  },
+  "val_metric": "ndcg_5",
+  "metrics": [
+    "ndcg_5",
+    "ndcg_10",
+    "ndcg_30",
+    "ndcg_60"
+  ],
+  "loss": {
+    "name": "lambdaLoss",
+    "args": {
+      "weighing_scheme": "lambdaRank_scheme",
+      "k": null,
+      "mu": 10,
+      "sigma": 1.0
+    }
+  },
+  "detect_anomaly": false,
+  "expected_metrics" : {
+    "val": {
+      "ndcg_5": 0.50
+    }
+  }
+}

--- a/reproducibility/configs/neuralndcg_web30k/neuralndcg_atmax.json
+++ b/reproducibility/configs/neuralndcg_web30k/neuralndcg_atmax.json
@@ -1,0 +1,68 @@
+{
+  "model": {
+    "fc_model": {
+      "sizes": [96],
+      "input_norm": false,
+      "activation": null,
+      "dropout": 0.0
+    },
+    "transformer": {
+      "N": 2,
+      "d_ff": 384,
+      "h": 1,
+      "positional_encoding" : null,
+      "dropout": 0.1
+    },
+    "post_model": {
+      "output_activation": "Tanh",
+      "d_output": 1
+    }
+  },
+  "data": {
+    "path": "MLSR-WEB30K-FOLD1-PATH",
+    "validation_ds_role": "test",
+    "num_workers": 1,
+    "batch_size": 64,
+    "slate_length": 240
+  },
+  "optimizer": {
+    "name": "Adam",
+    "args": {
+      "lr": 0.001
+    }
+  },
+  "lr_scheduler": {
+    "name": "StepLR",
+    "args": {
+      "step_size": 50,
+      "gamma": 0.1
+    }
+  },
+  "training": {
+    "epochs": 100,
+    "early_stopping_patience": 100,
+    "gradient_clipping_norm": null
+  },
+  "val_metric": "ndcg_5",
+  "metrics": [
+    "ndcg_5",
+    "ndcg_10",
+    "ndcg_30",
+    "ndcg_60"
+  ],
+  "loss": {
+    "name": "neuralNDCG",
+    "args": {
+      "temperature": 1.0,
+      "k": null,
+      "powered_relevancies": true,
+      "stochastic": false
+    }
+  },
+  "detect_anomaly": false,
+  "expected_metrics" : {
+    "val": {
+      "ndcg_5": 0.5
+    }
+  }
+}

--- a/reproducibility/normalize_features.py
+++ b/reproducibility/normalize_features.py
@@ -1,0 +1,89 @@
+import os
+from argparse import ArgumentParser, Namespace
+
+import numpy as np
+from sklearn.datasets import load_svmlight_file, dump_svmlight_file
+
+
+def parse_args() -> Namespace:
+    # default params
+    FEATURES_WITHOUT_LOGARITHM = [
+        5, 6, 7, 8, 9, 15, 19, 57, 58, 62, 75, 79, 85, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 121, 122, 127, 129, 130]
+    FEATURES_NEGATIVE = [110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 123, 124]
+
+    parser = ArgumentParser("Normalize features script")
+
+    parser.add_argument("--ds_path", help="location of the dataset", required=True, type=str)
+
+    parser.add_argument("--features_without_logarithm",
+                        help="indices of features which are to be normalized without being logarithmized", required=False,
+                        type=int, nargs="*", default=FEATURES_WITHOUT_LOGARITHM)
+
+    parser.add_argument("--features_negative",
+                        help="indices of features which are to be normalized with logarithm but their values can be negative",
+                        required=False, type=int, nargs="*" , default=FEATURES_NEGATIVE)
+
+    return parser.parse_args()
+
+
+args = parse_args()
+
+x_train, y_train, query_ids_train = load_svmlight_file(os.path.join(args.ds_path, "train.txt"), query_id=True)
+x_test, y_test, query_ids_test = load_svmlight_file(os.path.join(args.ds_path, "test.txt"), query_id=True)
+x_vali, y_vali, query_ids_vali = load_svmlight_file(os.path.join(args.ds_path, "vali.txt"), query_id=True)
+
+x_train_transposed = x_train.toarray().T
+x_test_transposed = x_test.toarray().T
+x_vali_transposed = x_vali.toarray().T
+
+x_train_normalized = np.zeros(x_train_transposed.shape)
+x_test_normalized = np.zeros(x_test_transposed.shape)
+x_vali_normalized = np.zeros(x_vali_transposed.shape)
+
+eps_log = 1e-2
+eps = 1e-6
+
+for i, feat in enumerate(x_train_transposed):
+    feature_vector_train = feat
+    feature_vector_test = x_test_transposed[i, ]
+    feature_vector_vali = x_vali_transposed[i, ]
+
+    if i in args.features_negative:
+        feature_vector_train = (-1) * feature_vector_train
+        feature_vector_test = (-1) * feature_vector_test
+        feature_vector_vali = (-1) * feature_vector_vali
+
+    if i not in args.features_without_logarithm:
+        # log only if all values >= 0
+        if np.all(feature_vector_train >= 0) & np.all(feature_vector_test >= 0) & np.all(feature_vector_vali >= 0):
+            feature_vector_train = np.log(feature_vector_train + eps_log)
+            feature_vector_test = np.log(feature_vector_test + eps_log)
+            feature_vector_vali = np.log(feature_vector_vali + eps_log)
+        else:
+            print("Some values of feature no. {} are still < 0 which is why the feature won't be normalized".format(i))
+
+    mean = np.mean(feature_vector_train)
+    std = np.std(feature_vector_train)
+    feature_vector_train = (feature_vector_train - mean) / (std + eps)
+    feature_vector_test = (feature_vector_test - mean) / (std + eps)
+    feature_vector_vali = (feature_vector_vali - mean) / (std + eps)
+    x_train_normalized[i, ] = feature_vector_train
+    x_test_normalized[i, ] = feature_vector_test
+    x_vali_normalized[i, ] = feature_vector_vali
+
+ds_normalized_path = "{}_normalized".format(args.ds_path)
+os.makedirs(ds_normalized_path, exist_ok=True)
+
+train_normalized_path = os.path.join(ds_normalized_path, "train.txt")
+with open(train_normalized_path, "w"):
+    dump_svmlight_file(x_train_normalized.T, y_train, train_normalized_path, query_id=query_ids_train)
+
+test_normalized_path = os.path.join(ds_normalized_path, "test.txt")
+with open(test_normalized_path, "w"):
+    dump_svmlight_file(x_test_normalized.T, y_test, test_normalized_path, query_id=query_ids_test)
+
+vali_normalized_path = os.path.join(ds_normalized_path, "vali.txt")
+with open(vali_normalized_path, "w"):
+    dump_svmlight_file(x_vali_normalized.T, y_vali, vali_normalized_path, query_id=query_ids_vali)
+
+print("Dataset with normalized features saved here: {}.".format(ds_normalized_path))

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ reqs = [
 
 setup(
     name="allRank",
-    version="1.4.1",
+    version="1.4.2",
     description="allRank is a framework for training learning-to-rank neural models",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR introduces a reproducibility guide for both papers ([Context-Aware Learning to Rank with Self-Attention](https://arxiv.org/abs/2005.10084) and [NeuralNDCG: Direct Optimisation of a Ranking Metric via Differentiable Relaxation of Sorting](https://arxiv.org/abs/2102.07831)) and [MSLR-WEB30K dataset](https://www.microsoft.com/en-us/research/project/mslr/).

Along with the markdown guide file, there are configuration files for selected losses and a script for data normalization.

Also, small memory usage fixes were made - we no longer multiply the batch size by 2 for the validation data loader and we perform masking in LambdaLoss in a slightly lighter way.