### PR TITLE
Fix for data loading with non-ascending query ids

### DIFF
--- a/allrank/data/dataset_loading.py
+++ b/allrank/data/dataset_loading.py
@@ -106,7 +106,8 @@ class LibSVMDataset(Dataset):
         """
         X = X.toarray()
 
-        groups = np.cumsum(np.unique(query_ids, return_counts=True)[1])
+        _, indices, counts = np.unique(query_ids, return_index=True, return_counts=True)
+        groups = np.cumsum(counts[np.argsort(indices)])
 
         self.X_by_qid = np.split(X, groups)[:-1]
         self.y_by_qid = np.split(y, groups)[:-1]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ reqs = [
 
 setup(
     name="allRank",
-    version="1.4.2",
+    version="1.4.3",
     description="allRank is a framework for training learning-to-rank neural models",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR fixes a bug where data for different, adjacent queries would get mixed up if the dataset wasn't sorted by ascending query ids.