### PR TITLE
Moves LayerNorm to output of the Encoder's sub-layers

### DIFF
--- a/allrank/models/transformer.py
+++ b/allrank/models/transformer.py
@@ -102,8 +102,8 @@ class SublayerConnection(nn.Module):
         :param sublayer: layer through which to pass the input prior to applying the sum
         :return: output of shape [batch_size, slate_length, output_dim]
         """
-        return x + self.dropout(
-            sublayer(self.norm(x)))
+        return self.norm(x + self.dropout(
+            sublayer(x)))
 
 
 class EncoderLayer(nn.Module):


### PR DESCRIPTION
Hi there,

As explained in https://github.com/allegro/allRank/issues/46, I believe that there is a minor lack of correspondence between the implementation and what's written in the paper ("Context-Aware Learning to Rank with Self-Attention") when it comes to the Transformer architecture. 

Sadly I can't say whether this in practice affects performance, as I'm attempting to utilize this work for something entirely different.
However, it looks like that with the fix, learning is a tad more stable.

At any rate, thank you once again for this work and publishing it!