### PR TITLE
use devices/dtypes based on passed in tensors

### DIFF
--- a/allrank/models/losses/bce.py
+++ b/allrank/models/losses/bce.py
@@ -2,7 +2,6 @@ import torch
 from torch.nn import BCELoss
 
 from allrank.data.dataset_loading import PADDED_Y_VALUE
-from allrank.models.model_utils import get_torch_device
 
 
 def bce(y_pred, y_true, padded_value_indicator=PADDED_Y_VALUE):
@@ -13,7 +12,7 @@ def bce(y_pred, y_true, padded_value_indicator=PADDED_Y_VALUE):
     :param padded_value_indicator: an indicator of the y_true index containing a padded item, e.g. -1
     :return: loss value, a torch.Tensor
     """
-    device = get_torch_device()
+    device = y_pred.device
 
     y_pred = y_pred.clone()
     y_true = y_true.clone()
@@ -25,7 +24,7 @@ def bce(y_pred, y_true, padded_value_indicator=PADDED_Y_VALUE):
     ls[mask] = 0.0
 
     document_loss = torch.sum(ls, dim=-1)
-    sum_valid = torch.sum(valid_mask, dim=-1).type(torch.float32) > torch.tensor(0.0, dtype=torch.float32, device=device)
+    sum_valid = torch.sum(valid_mask, dim=-1).type(y_pred.dtype) > torch.tensor(0.0, dtype=y_pred.dtype, device=device)
 
     loss_output = torch.sum(document_loss) / torch.sum(sum_valid)
 

--- a/setup.py
+++ b/setup.py
@@ -7,16 +7,16 @@ HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 
 reqs = [
-    "scikit-learn>=1.1.0, <=1.2.1",
-    "pandas>=1.0.5, <=1.3.5",
-    "numpy>=1.18.5, <=1.21.6",
-    "scipy>=1.4.1, <=1.7.3",
+    "scikit-learn>=1.1.0",
+    "pandas>=1.0.5",
+    "numpy>=1.18.5",
+    "scipy>=1.4.1",
     "attrs>=19.3.0",
     "flatten_dict>=0.3.0",
     "tensorboardX>=2.1.0",
-    "gcsfs==0.6.2",
+    "gcsfs>=0.6.2",
     "google-auth>=2.15.0",
-    "fsspec <= 2023.1.0"
+    "fsspec"
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ reqs = [
     "tensorboardX>=2.1.0",
     "gcsfs>=0.6.2",
     "google-auth>=2.15.0",
-    "fsspec"
+    "fsspec",
+    "torchvision",
 ]
 
 setup(


### PR DESCRIPTION
Hi, 

Thanks for putting together this repository. I'm using the loss functions only as a part of another project and using CPU/GPU at different times. I also use half precision training sometimes. This PR makes the loss functions use the device/dtypes of the passed in tensors rather than always using GPU/torch.float32. Since the training code still uses `get_torch_device()` and float32 tensors this should change the operation only when someone is using the loss functions separately (my use case)

Creating this PR in case it's useful to others. Obviously feel free to reject if you want to keep as is. 