### PR TITLE
added support for wandb logging

### DIFF
--- a/allrank/click_models/click_utils.py
+++ b/allrank/click_models/click_utils.py
@@ -10,7 +10,7 @@ from allrank.data.dataset_loading import PADDED_Y_VALUE
 def click_on_slates(slates: Union[Tuple[np.ndarray, np.ndarray], Tuple[torch.Tensor, torch.Tensor]],
                     click_model: ClickModel, include_empty: bool) -> Tuple[List[Union[np.ndarray, torch.Tensor]], List[List[int]]]:
     """
-    This metod runs a click model on a list of slates and returns new slates with `y` taken from clicks
+    This method runs a click model on a list of slates and returns new slates with `y` taken from clicks
 
     :param slates: a Tuple of X, y:
         X being a list of slates represented by document vectors

--- a/allrank/config.py
+++ b/allrank/config.py
@@ -76,6 +76,7 @@ class Config:
     expected_metrics = attrib(type=Dict[str, Dict[str, float]], default={})
     detect_anomaly = attrib(type=bool, default=False)
     click_model = attrib(type=Optional[NameArgsConfig], default=None)
+    wandb_project_id = attrib(type=str, default=None)
 
     @classmethod
     def from_json(cls, config_path):
@@ -97,6 +98,7 @@ class Config:
         config["metrics"] = cls._parse_metrics(config["metrics"])
         config["lr_scheduler"] = NameArgsConfig(**config["lr_scheduler"])
         config["loss"] = NameArgsConfig(**config["loss"])
+        config["wandb_project_id"] = config["wandb_project_id"]
         if "click_model" in config.keys():
             config["click_model"] = NameArgsConfig(**config["click_model"])
         return cls(**config)

--- a/scripts/local_config.json
+++ b/scripts/local_config.json
@@ -55,6 +55,7 @@
       "n": 4
     }
   },
+  "wandb_project_id": "allRank",
   "expected_metrics" : {
     "val": {
       "ndcg_5": 0.76

--- a/scripts/local_config_click_model.json
+++ b/scripts/local_config_click_model.json
@@ -55,6 +55,7 @@
       "n": 4
     }
   },
+  "wandb_project_id": "allRank",
   "expected_metrics" : {
     "val": {
       "ndcg_5": 0.76


### PR DESCRIPTION
Added `--wandb` flag to `main.py` which enables logging of train_loss, val_loss, and defined metrics, as well as artifacts to wandb.